### PR TITLE
Add support for the diffSeries function

### DIFF
--- a/grammars/TargetParser.pegjs
+++ b/grammars/TargetParser.pegjs
@@ -50,7 +50,7 @@ spaceFunctionName = ws* functionName:functionName
     { return functionName; }
 
 functionName
-    = "summarize" / "sumSeries" / "sum" / "averageSeries" / "avg" / "scale" / "aliasByNode" / "asPercent" / "alias" / "bestFit" / "sinFunction" / "sin" / "constantLine" / "offset" / "removeAboveValue" / "removeBelowValue" / "keepLastValue" / "integral" / "derivative"
+    = "summarize" / "sumSeries" / "sum" / "averageSeries" / "avg" / "scale" / "aliasByNode" / "asPercent" / "alias" / "bestFit" / "sinFunction" / "sin" / "constantLine" / "offset" / "removeAboveValue" / "removeBelowValue" / "keepLastValue" / "integral" / "derivative" / "diffSeries"
 
 spaceexpression  = ws* expression:expression
     { return expression; }

--- a/lib/TargetParseContext.js
+++ b/lib/TargetParseContext.js
@@ -18,6 +18,14 @@ function Matcher( original, matcher) {
     this.seriesList= [];
 }
 
+function isNone(value) {
+    return (typeof(value) == 'undefined' || value == null);
+}
+
+function isMetric(object) {
+  return !isNone(object) && !isNone(object.constructor) && object.constructor == Matcher;
+}
+
 /**
  * Find the set of metrics that match the given regular expression.
  */
@@ -31,7 +39,7 @@ TargetParseContext.prototype._expandMetrics= function( pMetric ) {
         }
         else {
             that.metricsStore.getAvailableMetrics( function( err, availableMetrics ) {
-                if( err ) throw err;
+                if( err ) deferred.reject(err);
                 var matchedMetrics= [];
                 for( var availableMetric in availableMetrics ) {
                     if( metric.matcher.test( availableMetric ) ) {
@@ -715,8 +723,92 @@ TargetParseContext.prototype.derivative= function( pa ) {
   });
 }
 
-function isNone(value) {
-    return (typeof(value) == 'undefined' || value == null);
+TargetParseContext.prototype.diffSeries= function() {
+  var that = this;
+  return Q.spread( arguments, function() {
+    var firstArg = arguments[0];
+    var firstArgIsMetric = isMetric(firstArg);
+    var deferred = Q.defer();
+    var newValues =[];
+    var metricsToResolve= [];
+    var notMetrics= [];
+    var metricParamNames = "";
+    for(var k=0; k < arguments.length; k++) {
+      if( isMetric(arguments[k]) ) {
+        metricsToResolve.push( that.$chkSeries( arguments[k], true, k ) );
+        metricParamNames += ("," + arguments[k].name);
+      }
+      else {
+        notMetrics.push( arguments[k] );
+        metricParamNames += ("," + arguments[k]);
+      }
+    };
+    metricParamNames = metricParamNames.substring(1);
+
+    Q.spread( metricsToResolve, function( ) {
+      var resolvedMetrics = Array.prototype.slice.call(arguments, 0);
+      var numVals = resolvedMetrics[0].seriesList[0].data.values.length;
+
+      var lhs = null;
+      if(firstArgIsMetric) {
+        if( firstArg.seriesList.length > 1) {
+          lhs= firstArg.seriesList.shift();
+        }
+        else {
+          lhs= resolvedMetrics.shift().seriesList[0];
+        }
+      }
+      else {
+        lhs = firstArg;
+        notMetrics.shift();
+      }
+      for(var i=0; i < numVals; i++) {
+        var lhsVal = 0;
+        if(firstArgIsMetric && !isNone(lhs.data.values[i])) {
+          lhsVal = lhs.data.values[i];
+        }
+        if(!firstArgIsMetric) {
+          lhsVal += firstArg;
+        }
+        
+        for(var j in resolvedMetrics) {
+          var diffLists = resolvedMetrics[j].seriesList;
+          for(var l=0; l < diffLists.length; l++) {
+            var dl = diffLists[l];
+              var valToDiff = dl.data.values[i];
+              if(!isNone(valToDiff)) {
+                lhsVal -= valToDiff;
+              }
+          }
+        }
+        for(var m=0; m < notMetrics.length; m++) {
+            lhsVal -= notMetrics[m];
+        }
+        newValues.push(lhsVal);
+      }
+      
+      var result= new Matcher("diffSeries("+metricParamNames+")");
+      result.expanded= true;
+      result.populated= true;
+      result.seriesList[0]= {
+          data: {
+          },
+          info: {
+          }
+      };
+      result.seriesList[0].data.tInfo = resolvedMetrics[0].seriesList[0].data.tInfo;
+      result.seriesList[0].data.values = newValues;
+      // Using the first series' aggregation method (no other choice really!)
+      result.seriesList[0].info.aggregationMethod = resolvedMetrics[0].seriesList[0].info.aggregationMethod;
+      result.seriesList[0].name = "diffSeries("+metricParamNames+")";
+      deferred.resolve(result);
+    })
+    .fail( function( err ) { 
+        deferred.reject( err );
+    });
+    return deferred.promise;
+    
+  });
 }
 
-module.exports= TargetParseContext;
+module.exports = TargetParseContext;

--- a/public/javascripts/chartled/builder/chartdFunctions.js
+++ b/public/javascripts/chartled/builder/chartdFunctions.js
@@ -20,6 +20,8 @@ chartd.functions = [
       description: "Produces a line of constant 'value'" },
     { name: 'derivative', example: 'derivative(metric*)',
       description: "Calculates the delta between consecutive data points of a running total metric. (Note: doesn't normalise for time, as a true derivative would)" },
+    { name: 'diffSeries', example: 'diffSeries(metric*/1.0)',
+      description: "Takes metrics, lists of metrics or constant values (in any order) and subtracts parameters 2 through n from parameter 1. One of parameters must be a metric." },
     { name: 'integral', example: 'integral(metric*)',
       description: "Shows the sum over time (like a continuous addition function). Useful for finding totals or trends in metrics that are collected per minute." },
     { name: 'keepLastValue', example: 'keepLastValue(metric*,limit=inf)',
@@ -34,7 +36,7 @@ chartd.functions = [
       description: "Scales a series by the provided factor"},
     { name: 'sin', example: 'sin("title",amplitude=1)',
       description: "Generates a sine function based on current time range (10s interval)"},
-    { name: 'summarize', example: 'summarize(requestContext, seriesList, intervalString, func="sum", alignToFrom=False)',
+    { name: 'summarize', example: 'summarize(metric*, intervalString, func="sum", alignToFrom=False)',
       description: 'Summarize the data into interval buckets of a certain size. Using the provided aggregation function.'},
     { name: 'sumSeries', example: 'sumSeries(metric*)',
       description: "Sums a series"}

--- a/test/ServerTests/DiffSeriesTests.js
+++ b/test/ServerTests/DiffSeriesTests.js
@@ -1,0 +1,78 @@
+var assert= require("assert"),
+    TargetParseContext= require("../../lib/TargetParseContext"),
+    MetricInfo= require("../../lib/MetricInfo"),
+    TargetParser= require("../../lib/TargetParser"),
+    Utils= require("./TestUtils");
+
+describe('TargetParseContext', function(){
+  describe('diffSeries', function(){
+    it('should subtract constant values and a series list from a series', function(done) {
+        var metric=  "diffSeries(foo.bar,10,foo.{car,tar})";
+        var ctx= Utils.buildTargetParseContext( metric,  [new MetricInfo("foo.bar"), new MetricInfo("foo.car"), new MetricInfo("foo.tar")],
+                          {"foo.bar":[100,90,80,70,60,50,40,30,20,10,null], "foo.car":[1,1,1,1,1,1,1,1,1,1,1], "foo.tar":[5,4,3,2,1,1,2,3,4,5,1]} );
+        TargetParser.parse( metric )(ctx)
+                    .then(function (result) {
+                            assert.equal( 1, result.seriesList.length );
+                            assert.equal( 11, result.seriesList[0].data.values.length );
+                            assert.equal( "diffSeries(foo.bar,10,foo.{car,tar})", result.seriesList[0].name );
+                            assert.deepEqual( [84,75,66,57,48,38,27,16,5,-6,-12], result.seriesList[0].data.values );
+                            done();
+                    })
+                    .end();
+    });
+    it('should subtract a series from a constant value (handling nulls and undefined)', function(done) {
+        var metric=  "diffSeries(1000, foo.bar)";
+        var ctx= Utils.buildTargetParseContext( metric,  [new MetricInfo("foo.bar")], {"foo.bar":[null,100,null,200,undefined,300,400,500,null,undefined]} );
+        TargetParser.parse( metric )(ctx)
+                    .then(function (result) {
+                            assert.equal( 1, result.seriesList.length );
+                            assert.equal( 10, result.seriesList[0].data.values.length );
+                            assert.equal( "diffSeries(1000,foo.bar)", result.seriesList[0].name );
+                            assert.deepEqual( [1000,900,1000,800,1000,700,600,500,1000,1000], result.seriesList[0].data.values );
+                            done();
+                    })
+                    .end();
+    });
+    it('should subtract series 2 through \'n\' in a multiple series list from series 1 (handling nulls and undefined)', function(done) {
+        var metric=  "diffSeries(foo.{bar,car,tar})";
+        var ctx= Utils.buildTargetParseContext( metric,  [new MetricInfo("foo.bar"), new MetricInfo("foo.car"), new MetricInfo("foo.tar")],
+                          {"foo.bar":[100,null,80,70,60,undefined,40,30,20,10,null], "foo.car":[1,1,1,1,5,1,1,null,3,1,1], "foo.tar":[5,4,3,2,undefined,1,2,3,null,5,1]} );
+        TargetParser.parse( metric )(ctx)
+                    .then(function (result) {
+                            assert.equal( 1, result.seriesList.length );
+                            assert.equal( 11, result.seriesList[0].data.values.length );
+                            assert.equal( "diffSeries(foo.{bar,car,tar})", result.seriesList[0].name );
+                            assert.deepEqual( [94,-5,76,67,55,-2,37,27,17,4,-2], result.seriesList[0].data.values );
+                            done();
+                    })
+                    .end();
+    });
+    it('should subtract series 2 through \'n\' in a wild card series list from series 1 (handling nulls and undefined)', function(done) {
+        var metric=  "diffSeries(*.*, 0)";
+        var ctx= Utils.buildTargetParseContext( metric,  [new MetricInfo("foo.bar"), new MetricInfo("foo.car"), new MetricInfo("foo.tar")],
+                          {"foo.bar":[100,null,80,70,60,undefined,40,30,20,10,null], "foo.car":[1,1,1,1,5,1,1,null,3,1,1], "foo.tar":[5,4,3,2,undefined,1,2,3,null,5,1]} );
+        TargetParser.parse( metric )(ctx)
+                    .then(function (result) {
+                            assert.equal( 1, result.seriesList.length );
+                            assert.equal( 11, result.seriesList[0].data.values.length );
+                            assert.equal( "diffSeries(*.*,0)", result.seriesList[0].name );
+                            assert.deepEqual( [94,-5,76,67,55,-2,37,27,17,4,-2], result.seriesList[0].data.values );
+                            done();
+                    })
+                    .end();
+    });
+     it('should subtract series 2 through \'n\' in a range series list from series 1 (handling nulls and undefined)', function(done) {
+        var metric=  "diffSeries(foo.[12]ar)";
+        var ctx= Utils.buildTargetParseContext( metric,  [new MetricInfo("foo.1ar"), new MetricInfo("foo.2ar"), new MetricInfo("foo.12ar"), new MetricInfo("foo.21ar")], {"foo.1ar":[1,2,null,4], "foo.2ar":[10,20,30,undefined], "foo.12ar":[undefined,20,30,50], "foo.21ar":[10,20,null,50]} );
+        TargetParser.parse( metric )(ctx)
+                    .then(function (result) {
+                            assert.equal( 1, result.seriesList.length );
+                            assert.equal( 4, result.seriesList[0].data.values.length );
+                            assert.equal( "diffSeries(foo.[12]ar)", result.seriesList[0].name );
+                            assert.deepEqual( [-9,-38,-60,-46], result.seriesList[0].data.values );
+                            done();
+                    })
+                    .end();
+    });
+  });
+});


### PR DESCRIPTION
The diffSeries function subtracts metrics, lists of metrics and
constant values (parameters 2 through n) from parameter 1 - which
in turn is fleixible and could be a metric, list of metrics or a
constant value. Order of parameters 2 through n is not important.
Where as parameter 1 provides the initial value or list of values
to subtract from

Examples of usage:

```
diffSeries(5, foo.bar);
diffSeries(foo.*, 2, meep.bar);
diffSeries(*.*);
```
