### PR TITLE
gh-9 : Adds support for back-fetching of older data in movingAverage

### DIFF
--- a/grammars/TargetParser.pegjs
+++ b/grammars/TargetParser.pegjs
@@ -1,7 +1,7 @@
 start =
     expression: expression
     { 
-        var f= eval( "(function( ctx )  {\n return ctx.$chkSeries(" + expression + ", true, 0).then(function(metric){return metric.seriesList;});\n})" );
+        var f= eval( "(function( ctx )  {\n return ctx.$chkSeries(" + expression + ", true, 0, 0).then(function(metric){return metric.seriesList;});\n})" );
         //console.log( f.toString() );
         return f;
     }

--- a/lib/TargetParseContext.js
+++ b/lib/TargetParseContext.js
@@ -100,7 +100,7 @@ TargetParseContext.prototype.$m= function( val ) {
     return m;
 }
 
-TargetParseContext.prototype.$chkSeries= function( pa, populateMetrics, offset ) {
+TargetParseContext.prototype.$chkSeries= function( pa, populateMetrics, fromOffset, toOffset ) {
     var that= this;
     return Q.when( pa, function(value) {
         var deferred = Q.defer();
@@ -111,7 +111,7 @@ TargetParseContext.prototype.$chkSeries= function( pa, populateMetrics, offset )
             // We need to expand (or populate) the metric.
             var funcs = [];
             if(!value.expanded) funcs.push( function(val){ return that._expandMetrics(val); } );
-            if(!value.populated && populateMetrics) funcs.push( function(val){ return that._populateMetrics(val, that.from + offset, that.to + offset); } );
+            if(!value.populated && populateMetrics) funcs.push( function(val){ return that._populateMetrics(val, that.from + fromOffset, that.to + toOffset); } );
             
             if( funcs.length >0 ) {
                 funcs.reduce(function (soFar, f) {
@@ -193,13 +193,13 @@ TargetParseContext.prototype.asPercent= function ( pa, pt ) {
   // optional argument without complicating this logic here.
   return Q.spread( [pa, pt], function( value, optionalTarget ) {
       var deferred = Q.defer();
-      that.$chkSeries( value, true, 0).then( function( populatedMetric ) {
+      that.$chkSeries( value, true, 0, 0).then( function( populatedMetric ) {
         // Define the function that does that magic..
         var seriesCount= populatedMetric.seriesList.length;
 
         // Second argument is a Series of some description we'll need to resolve it first as well...
         if( optionalTarget && optionalTarget.constructor && optionalTarget.constructor == Matcher ) {
-          that.$chkSeries( optionalTarget, true, 0).then( function( populatedTargetMetric ) {
+          that.$chkSeries( optionalTarget, true, 0, 0).then( function( populatedTargetMetric ) {
             _asPercent( populatedMetric, populatedTargetMetric, deferred );
           });
         }
@@ -342,7 +342,7 @@ TargetParseContext.prototype._simpleFactorApplication= function( pa, pFactor, fu
     var that= this;
     return Q.spread( [pa, pFactor], function(value, factor) {
         var deferred = Q.defer();
-        that.$chkSeries( value, true, 0)
+        that.$chkSeries( value, true, 0, 0)
             .then( function( populatedMetric ) {
                 for( var k in populatedMetric.seriesList) {
                     var series= populatedMetric.seriesList[k];
@@ -389,7 +389,7 @@ TargetParseContext.prototype.sum=TargetParseContext.prototype.sumSeries= functio
     var that= this;
     return Q.when( pa, function(value) {
         var deferred = Q.defer();
-        that.$chkSeries( value, true, 0).then( function( populatedMetric ) {
+        that.$chkSeries( value, true, 0, 0).then( function( populatedMetric ) {
             populatedMetric.seriesList= SeriesUtils.sumSeriesList( populatedMetric.seriesList );
             // Update the title (even when a single series is passed )
             if( populatedMetric.seriesList.length > 0 ){ 
@@ -411,7 +411,7 @@ TargetParseContext.prototype.bestFit= function( pa ) {
   var that= this;
   return Q.when( pa, function(value) {
       var deferred = Q.defer();
-      that.$chkSeries( value, true, 0).then( function( populatedMetric ) {
+      that.$chkSeries( value, true, 0, 0).then( function( populatedMetric ) {
         var fittedSeries= { data: {},
                             info: {}
         };
@@ -479,7 +479,7 @@ TargetParseContext.prototype.alias= function ( pa, palias ) {
     var that= this;
     return Q.spread( [pa, palias], function(value, alias) {
         var deferred = Q.defer();
-        that.$chkSeries( value,false,0 ).then( function( populatedMetric ) {
+        that.$chkSeries( value,false, 0, 0 ).then( function( populatedMetric ) {
             var seriesCount= populatedMetric.seriesList.length;
             populatedMetric.name= "alias("+ populatedMetric.name +",\""+ alias + "\")";
             for( var seriesKey in populatedMetric.seriesList ) {
@@ -503,7 +503,7 @@ TargetParseContext.prototype.aliasByNode= function ( pa, palias ) {
     var that= this;
     return Q.spread( [pa, palias], function(value, alias) {
         var deferred = Q.defer();
-        that.$chkSeries( value,false,0 ).then( function( populatedMetric ) {
+        that.$chkSeries( value,false,0, 0 ).then( function( populatedMetric ) {
             var seriesCount= populatedMetric.seriesList.length;
             populatedMetric.name= "aliasByNode("+ populatedMetric.name +",\""+ alias + "\")";
             for( var seriesKey in populatedMetric.seriesList ) {
@@ -564,7 +564,7 @@ TargetParseContext.prototype.timeShift= function( pa, pintervalString ) {
 
     var delta= DatesAndTimes.parseTimeOffset(intervalString);
 
-    that.$chkSeries( value, true, delta )
+    that.$chkSeries( value, true, delta, delta )
         .then( function( populatedMetric ) {
             for( var seriesKey in populatedMetric.seriesList ) {
                 var series= populatedMetric.seriesList[seriesKey];
@@ -643,7 +643,7 @@ TargetParseContext.prototype.summarize= function( pa, pintervalString, paggregat
       }
     }
     var deferred = Q.defer();
-    that.$chkSeries( value, true,0 )
+    that.$chkSeries( value, true,0,0 )
         .then( function( populatedMetric ) {
             var interval= DatesAndTimes.parseTimeOffset(intervalString);
             // 're-quote' the interval string for display later.
@@ -748,7 +748,7 @@ TargetParseContext.prototype.keepLastValue= function( pa, plimit ) {
   return Q.spread( [pa, plimit], function( value, limit ) {
       if( typeof(limit) == 'undefined' ) limit = Infinity;
       var deferred = Q.defer();
-      that.$chkSeries( value, true,0 ).then( function( populatedMetric ) {
+      that.$chkSeries( value, true,0,0 ).then( function( populatedMetric ) {
         // Iterate over each series in the seriesList
         for( var i=0; i < populatedMetric.seriesList.length; i++ ) {
           populatedMetric.seriesList[i].name = "keepLastValue(" + populatedMetric.seriesList[i].name + ")";
@@ -798,7 +798,7 @@ TargetParseContext.prototype.integral= function( pa ) {
   var that= this;
   return Q.when( pa, function( value ) {
       var deferred = Q.defer();
-      that.$chkSeries( value, true,0 ).then( function( populatedMetric ) {
+      that.$chkSeries( value, true,0,0 ).then( function( populatedMetric ) {
         for( var i=0; i < populatedMetric.seriesList.length; i++ ) {
           populatedMetric.seriesList[i].name = "integral(" + populatedMetric.seriesList[i].name + ")";
           var current = 0;
@@ -823,7 +823,7 @@ TargetParseContext.prototype.derivative= function( pa ) {
   var that= this;
   return Q.when( pa, function( value ) {
       var deferred = Q.defer();
-      that.$chkSeries( value, true,0 ).then( function( populatedMetric ) {
+      that.$chkSeries( value, true,0,0 ).then( function( populatedMetric ) {
         for( var i=0; i < populatedMetric.seriesList.length; i++ ) {
           populatedMetric.seriesList[i].name = "derivative(" + populatedMetric.seriesList[i].name + ")";
           var newValues = [];
@@ -862,7 +862,7 @@ TargetParseContext.prototype.diffSeries= function() {
     var metricParamNames = "";
     for(var k=0; k < arguments.length; k++) {
       if( isMetric(arguments[k]) ) {
-        metricsToResolve.push( that.$chkSeries( arguments[k], true, 0 ) );
+        metricsToResolve.push( that.$chkSeries( arguments[k], true, 0, 0 ) );
         metricParamNames += ("," + arguments[k].name);
       }
       else {
@@ -949,20 +949,30 @@ TargetParseContext.prototype.movingAverage= function( pa, pWindowSize ) {
   var that= this;
   return Q.spread( [pa, pWindowSize], function( value, windowSize ) {
       var deferred = Q.defer();
-      that.$chkSeries( value, true, 0 ).then( function( populatedMetric ) {
-        var numberOfTimeSteps = windowSize;        
-        if(!isNone(numberOfTimeSteps) && isNumber(numberOfTimeSteps)) {
-            numberOfTimeSteps = parseInt(numberOfTimeSteps,10);
-        }
-        else if(!isNone(numberOfTimeSteps) && typeof(windowSize) == 'string') {
-          numberOfTimeSteps = Math.floor(DatesAndTimes.parseTimeOffset(windowSize) / populatedMetric.seriesList[0].data.tInfo[2]);
-          windowSize = "\"" + windowSize + "\"";
-        }
-        else {
-          deferred.reject( new Error("Unexpected windowSize parameter value of: " + windowSize + " - valid window sizes are integers or time strings.") );
+      var timeInterval = null;
+      if(typeof(windowSize) != 'string') {
+        deferred.reject( new Error("Unexpected windowSize parameter value of: " + windowSize + " - valid window sizes are time strings.") );
+        return;
+      }
+      try {
+        timeInterval = DatesAndTimes.parseTimeOffset(windowSize);
+      }
+      catch (err) {
+        deferred.reject( new Error("Unexpected windowSize parameter value of: " + windowSize + " - valid window sizes are time strings.") );
+        return;
+      }
+      windowSize = "\"" + windowSize + "\"";
+      var delta = (timeInterval * -1);
+      that.$chkSeries( value, true, delta, 0 ).then( function( populatedMetric ) {
+        var result = new Matcher("movingAverage(" + populatedMetric.name + "," + windowSize + ")");
+        var numberOfTimeSteps = Math.floor(timeInterval / populatedMetric.seriesList[0].data.tInfo[2]);
+        if(numberOfTimeSteps == 0) {
+          for( var i=0; i < populatedMetric.seriesList.length; i++ ) {
+            populatedMetric.seriesList[i].name = "movingAverage(" + populatedMetric.seriesList[i].name + "," + windowSize + ")";
+          }
+          deferred.resolve( populatedMetric );
           return;
         }
-        var result= new Matcher("movingAverage(" + populatedMetric.name + "," + windowSize + ")");
         result.expanded= true;
         result.populated= true;
         for( var i=0; i < populatedMetric.seriesList.length; i++ ) {
@@ -982,36 +992,30 @@ TargetParseContext.prototype.movingAverage= function( pa, pWindowSize ) {
           for( var k=0; k < valuesLength; k++) {
             var val = populatedMetric.seriesList[i].data.values[k];
             var nullVal = isNone(val);
-            var start = k - numberOfTimeSteps;
-            if ( start < 0 ) { start = 0 };
-            if( k == 0 ) { 
-              if( nullVal ) {
-                continue;
-              }
-              else {
-                currentSafeSum += val;
-                currentSafeLength += 1;
-              }
-            }
-            else {
-              var leftVal = populatedMetric.seriesList[i].data.values[start - 1];
-              if(!isNone(leftVal)) {
-                currentSafeSum -= leftVal;
-                currentSafeLength -= 1;
-              }
+            if( k < numberOfTimeSteps) {
               if(!nullVal){
                 currentSafeSum += val;
                 currentSafeLength += 1;
               }
+              continue;
+            }
+            if(!nullVal){
+              currentSafeSum += val;
+              currentSafeLength += 1;
+            }
+            var leftVal = populatedMetric.seriesList[i].data.values[k-numberOfTimeSteps];
+            if(!isNone(leftVal)) {
+              currentSafeSum -= leftVal;
+              currentSafeLength -= 1;
             }
             if(currentSafeLength == 0) {
               if(k == (valuesLength - 1)) {
-                result.seriesList[i].data.values[k] = val;
+                result.seriesList[i].data.values[k-numberOfTimeSteps] = val;
               }
-              continue;
+            continue;
             }
             var windowAvg = currentSafeSum / currentSafeLength;
-            result.seriesList[i].data.values[k] = windowAvg;
+            result.seriesList[i].data.values[k-numberOfTimeSteps] = windowAvg;
           }
         }
         deferred.resolve( result );
@@ -1027,14 +1031,14 @@ TargetParseContext.prototype.limit= function( pa, pLimit ) {
   var that= this;
   return Q.spread( [pa, pLimit], function( value, limit ) {
       var deferred = Q.defer();
-      that.$chkSeries( value, false ).then( function( populatedMetric ) {
+      that.$chkSeries( value, false, 0, 0 ).then( function( populatedMetric ) {
         populatedMetric.name = "limit(" + populatedMetric.name + "," + limit + ")";
         if(isNone(limit) || !isNumber(limit)) {
           deferred.reject( new Error("Invalid limit parameter value of: " + limit + ".") );
         }
         else {
           populatedMetric.seriesList.splice(limit - 1, value.seriesList.length - limit);
-          deferred.resolve( that.$chkSeries( populatedMetric, true, 0) );
+          deferred.resolve( that.$chkSeries( populatedMetric, true, 0, 0) );
         }
       })
       .fail( function( err ) { 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   }, 
   "scripts" : {
     "buildclient" : "node scripts/buildclient.js",
-    "test" : "mocha test/*/*.js --reporter dot  --timeout 200",
+    "test" : "mocha test/*/*.js --reporter dot  --timeout 2000",
     "prepublish" : "node scripts/prepublish.js",
     "generateparser": "node scripts/generateparser.js",
     "postinstall" : "node scripts/prepublish.js",

--- a/public/javascripts/chartled/builder/chartdFunctions.js
+++ b/public/javascripts/chartled/builder/chartdFunctions.js
@@ -29,7 +29,7 @@ chartd.functions = [
     { name: 'limit', example: 'keepLastValue(limit*,2)',
       description: "Takes one metric or a wildcard metric, and a limit to the number of metrics to return. Useful for returning first n metrics from a large list of metrics." },      
     { name: 'movingAverage', example: 'movingAverage(metric*,windowSize)',
-      description: "Graphs the moving average of a metric (or metrics) over a fixed number of past points, or a time interval." },
+      description: "Graphs the moving average of a metric (or metrics) over a time interval." },
     { name: 'offset', example: 'offset(metric*, factor)',
       description: "Takes a metric or a wildcard metric followed by a constant that will be applied to each point." },
     { name: 'removeAboveValue', example: 'removeAboveValue(metric*, 3)',

--- a/test/ServerTests/TargetParser.js
+++ b/test/ServerTests/TargetParser.js
@@ -10,7 +10,7 @@ describe('TargetParser', function(){
   describe('#parse()', function(){
     it('should parse scale(stats.gauges.overwatch.backlog,1)', function(){
         var functionString= TargetParser.parse( "scale(stats.gauges.overwatch.backlog,1)" ).toString() ;
-        assert.ok( functionString.indexOf("ctx.$chkSeries(ctx.scale(ctx.$m({\"o\":\"stats.gauges.overwatch.backlog\",\"r\":\"^stats\\\\.gauges\\\\.overwatch\\\\.backlog$\"}),ctx.$(1)), true, 0)") != -1 );
+        assert.ok( functionString.indexOf("ctx.$chkSeries(ctx.scale(ctx.$m({\"o\":\"stats.gauges.overwatch.backlog\",\"r\":\"^stats\\\\.gauges\\\\.overwatch\\\\.backlog$\"}),ctx.$(1)), true, 0, 0)") != -1 );
     })
     it('should parse scale(avg(stats.*.processor.[7].pct_processor_time),100)', function(){
         TargetParser.parse( "scale(avg(stats.*.processor.[7].pct_processor_time),100)" );


### PR DESCRIPTION
Although this adds support for back-fetching it removed the ability
to definie an arbitary number of timeSteps by integer.

If a moving average smaller than the timestep (or zero seconds etc)
the original metric is returned unchanged.
